### PR TITLE
added Encoding parameter with value Unicode

### DIFF
--- a/Monitor-ADGroupMemberShip.ps1
+++ b/Monitor-ADGroupMemberShip.ps1
@@ -629,7 +629,7 @@ PROCESS
 					{
 						Write-Verbose -Message "[PROCESS] $item - The following file did not exist: $StateFile"
 						Write-Verbose -Message "[PROCESS] $item - Exporting the current membership information into the file: $StateFile"
-						$Members | Export-csv -Path (Join-Path -Path $ScriptPathOutput -ChildPath $StateFile) -NoTypeInformation
+						$Members | Export-csv -Path (Join-Path -Path $ScriptPathOutput -ChildPath $StateFile) -NoTypeInformation -Encoding Unicode
 					}
 					ELSE
 					{
@@ -701,12 +701,12 @@ PROCESS
 						
 						IF (-not (Test-Path -path (Join-Path -Path $ScriptPathChangeHistory -ChildPath "$($DomainName)_$($RealGroupName)-ChangeHistory.csv")))
 						{
-							$Changes | Export-Csv -Path (Join-Path -Path $ScriptPathChangeHistory -ChildPath "$($DomainName)_$($RealGroupName)-ChangeHistory.csv") -NoTypeInformation
+							$Changes | Export-Csv -Path (Join-Path -Path $ScriptPathChangeHistory -ChildPath "$($DomainName)_$($RealGroupName)-ChangeHistory.csv") -NoTypeInformation -Encoding Unicode
 						}
 						ELSE
 						{
 							#$Changes | Export-Csv -Path (Join-Path -Path $ScriptPathChangeHistory -ChildPath "$DomainName_$RealGroupName-ChangeHistory-$DateFormat.csv") -NoTypeInformation
-							$Changes | Export-Csv -Path (Join-Path -Path $ScriptPathChangeHistory -ChildPath "$($DomainName)_$($RealGroupName)-ChangeHistory.csv") -NoTypeInformation -Append
+							$Changes | Export-Csv -Path (Join-Path -Path $ScriptPathChangeHistory -ChildPath "$($DomainName)_$($RealGroupName)-ChangeHistory.csv") -NoTypeInformation -Append -Encoding Unicode
 						}
 						
 						


### PR DESCRIPTION
Line 774 contains parameter Encoding with Unicode as value
However previously on lines 632, 704, and 709 this value is not defined
This means that there will be a mismatch for all users with unicode
characters in their names, all of these users will be shown as removed
and added, which will trigger emails for every group they are a member
of.

By providing this parameter this issue is solved