### PR TITLE
Single Member bugfix

### DIFF
--- a/Monitor-ADGroupMemberShip.ps1
+++ b/Monitor-ADGroupMemberShip.ps1
@@ -638,7 +638,7 @@ PROCESS
 						
 						# Look for Members
 						$MemberObjs = Get-ADGroupMember @GroupMemberSplatting -Recursive -ErrorAction Stop -ErrorVariable ErrorProcessGetADGroupMember
-						$Members = $MemberObjs | Where-Object {$_.objectClass -eq "user"}| get-aduser -Properties PasswordExpired  | Select-Object -Property *,@{ Name = 'DN'; Expression = { $_.DistinguishedName } }
+						[Array]$Members = $MemberObjs | Where-Object {$_.objectClass -eq "user"}| get-aduser -Properties PasswordExpired  | Select-Object -Property *,@{ Name = 'DN'; Expression = { $_.DistinguishedName } }
                         			$Members += $MemberObjs | Where-Object {$_.objectClass -eq "computer"}| Get-ADComputer -Properties PasswordExpired  | Select-Object -Property *,@{ Name = 'DN'; Expression = { $_.DistinguishedName } }
                         
 					}


### PR DESCRIPTION
Found a bug in my code addition that caused a failure in the case where the group only had a single member. i.e. line 642 would cause a bug when the $member var only had a single entry, causing it to just be a custom psobject and not an array, therefore it didn't have an op_addition method. Typecasting the var as an array fixes the issue.